### PR TITLE
fix: update header font size for mobile screens

### DIFF
--- a/src/components/header/style.scss
+++ b/src/components/header/style.scss
@@ -33,3 +33,9 @@
     }
   }
 }
+
+@media screen and (max-width: 375px) {
+  .header {
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
Converted from:

![image](https://user-images.githubusercontent.com/22245039/198118317-4b0a6251-e093-43d7-9bf0-11d8ac5409b1.png)

to:

![image](https://user-images.githubusercontent.com/22245039/198118377-d1368ad1-c6dd-4ba3-b44e-774c69b05c69.png)

